### PR TITLE
Add light mode toggle to side menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -231,8 +231,11 @@
     .login-panel input[type="text"]:focus { outline: none; border-color: #00bcd4; box-shadow: 0 0 0 3px rgba(0, 188, 212, 0.2); }
     .login-panel button { padding: 0.6rem 1.2rem; border-radius: 8px; border: none; background: #00bcd4; color: #fff; font-weight: 600; cursor: pointer; transition: background 0.2s ease; }
     .login-panel button:hover { background: #0097a7; }
-    .login-panel .external-link { margin-top: 0.75rem; display: inline-block; color: #00bcd4; font-weight: 600; text-decoration: none; transition: color 0.2s ease; }
+    .login-panel .external-links { list-style: none; margin: 0.75rem 0 0; padding: 0; display: flex; flex-direction: column; gap: 0.5rem; }
+    .login-panel .external-link { display: inline-flex; color: #00bcd4; font-weight: 600; text-decoration: none; transition: color 0.2s ease; }
     .login-panel .external-link:hover { color: #ff9800; text-decoration: underline; }
+    .theme-toggle { margin-top: auto; padding: 0.65rem 1.2rem; border-radius: 999px; border: none; font-weight: 600; cursor: pointer; background: #333; color: #f5f5f5; box-shadow: 0 4px 12px rgba(0,0,0,0.25); transition: transform 0.2s ease, background 0.2s ease; width: 100%; text-align: center; }
+    .theme-toggle:hover { transform: translateY(-1px); background: #3f3f3f; }
     #logout-button { margin-top: 0.75rem; width: 100%; background: #ef5350; }
     #logout-button:hover { background: #e53935; }
     .login-hint { margin-top: 0.75rem; font-size: 0.9rem; color: #ccc; }
@@ -252,6 +255,48 @@
 
     /* Motion safety */
     @media (prefers-reduced-motion: reduce) { #menu-backdrop, #side-menu, #menu-toggle { transition: none !important; } }
+
+    /* ===== Light mode overrides ===== */
+    body.light-mode { background: #f5f6f9; color: #1f1f1f; }
+    body.light-mode h1 { color: #c62828; text-shadow: 0 0 10px rgba(198, 40, 40, 0.25); }
+    body.light-mode .question-text { background: #ffffff; border-left-color: #c62828; color: #1f1f1f; box-shadow: 0 3px 10px rgba(0,0,0,0.1); }
+    body.light-mode .question-result { color: #c62828; }
+    body.light-mode .cell { background: #ffffff; border-color: #cfd8dc; color: #263238; }
+    body.light-mode .cell.green { background: #81c784; border-color: #4caf50; color: #0a2510; }
+    body.light-mode .cell.yellow { background: #fff176; border-color: #fdd835; color: #4a3d00; }
+    body.light-mode .cell.gray { background: #cfd8dc; border-color: #b0bec5; color: #37474f; }
+    body.light-mode #submit { background: #1976d2; color: #fff; }
+    body.light-mode #submit:hover { background: #1565c0; box-shadow: 0 4px 10px rgba(21, 101, 192, 0.25); }
+    body.light-mode #start-screen { background: rgba(245, 246, 249, 0.97); color: #1f1f1f; }
+    body.light-mode #menu-toggle { background: #1976d2; color: #fff; }
+    body.light-mode #menu-toggle:hover { background: #1565c0; }
+    body.light-mode.menu-open #menu-toggle { background: #115293; color: #e3f2fd; }
+    body.light-mode #menu-backdrop { background: rgba(0,0,0,0.35); }
+    body.light-mode #side-menu { background: #ffffff; box-shadow: 8px 0 24px rgba(33, 33, 33, 0.18); }
+    body.light-mode #side-menu h2 { color: #1976d2; text-shadow: none; }
+    body.light-mode #side-menu p { color: #37474f; }
+    body.light-mode .login-panel { background: #f1f5f9; border: 1px solid #cfd8dc; box-shadow: 0 6px 14px rgba(33, 33, 33, 0.12); }
+    body.light-mode .login-panel input[type="text"] { background: #fff; border-color: #b0bec5; color: #1f1f1f; }
+    body.light-mode .login-panel input[type="text"]:focus { border-color: #1976d2; box-shadow: 0 0 0 3px rgba(25, 118, 210, 0.2); }
+    body.light-mode .login-panel button { background: #1976d2; }
+    body.light-mode .login-panel button:hover { background: #1565c0; }
+    body.light-mode .login-panel .external-link { color: #1976d2; }
+    body.light-mode .login-panel .external-link:hover { color: #ef6c00; }
+    body.light-mode #logout-button { background: #e53935; }
+    body.light-mode #logout-button:hover { background: #c62828; }
+    body.light-mode .login-hint { color: #607d8b; }
+    body.light-mode .streak-panel { background: #ffffff; border-color: #e0e0e0; box-shadow: 0 4px 12px rgba(0,0,0,0.08); }
+    body.light-mode .streak-panel h3 { color: #d84315; }
+    body.light-mode #streak-count { color: #c62828; }
+    body.light-mode .streak-note { color: #546e7a; }
+    body.light-mode .auth-status { color: #37474f; }
+    body.light-mode #timer { color: #c62828; }
+    body.light-mode footer { color: #607d8b; border-top-color: #cfd8dc; }
+    body.light-mode .share-button.copy { background: #eceff1; color: #263238; }
+    body.light-mode .tracker-char { background: #eceff1; color: #d84315; border-color: #cfd8dc; }
+    body.light-mode .tracker-char.used { color: #90a4ae; }
+    body.light-mode .theme-toggle { background: #1976d2; color: #fff; box-shadow: 0 4px 12px rgba(25,118,210,0.25); }
+    body.light-mode .theme-toggle:hover { background: #1565c0; }
   </style>
 </head>
 <body>
@@ -284,7 +329,10 @@
       </form>
       <button id="logout-button" type="button" style="display: none;">Log Out</button>
       <p class="login-hint">Your daily streak is saved per username on this device.</p>
-      <a class="external-link" href="https://cordell33.github.io/GodlePuzzle/" target="_blank" rel="noopener noreferrer">Godle (daily)</a>
+      <ul class="external-links">
+        <li><a class="external-link" href="https://cordell33.github.io/GodlePuzzle/" target="_blank" rel="noopener noreferrer">Godle (daily)</a></li>
+        <li><a class="external-link" href="https://cordell33.github.io/Cordlle/" target="_blank" rel="noopener noreferrer">Cordlle (monthly)</a></li>
+      </ul>
     </div>
     <div id="auth-status" class="auth-status" style="display:none;">Logged in as <strong id="current-username"></strong></div>
     <div class="streak-panel" id="streak-panel" hidden>
@@ -294,6 +342,7 @@
       </div>
       <small class="streak-note">Increments when you log in during a new week (Sun–Sat, your local time).</small>
     </div>
+    <button id="theme-toggle" class="theme-toggle" type="button" aria-pressed="false">Enable light mode</button>
   </aside>
 
   <h1>Gödle Hex</h1>
@@ -369,6 +418,39 @@
         const last = items[items.length - 1];
         if (e.shiftKey && document.activeElement === first) { e.preventDefault(); last.focus(); }
         else if (!e.shiftKey && document.activeElement === last) { e.preventDefault(); first.focus(); }
+      });
+    })();
+  </script>
+
+  <script>
+    // ===== Theme Toggle =====
+    (function(){
+      const toggleBtn = document.getElementById('theme-toggle');
+      if (!toggleBtn) return;
+
+      const LIGHT_CLASS = 'light-mode';
+      const STORAGE_KEY = 'ghx_light_mode';
+
+      function applyMode(isLight){
+        document.body.classList.toggle(LIGHT_CLASS, isLight);
+        toggleBtn.setAttribute('aria-pressed', String(isLight));
+        toggleBtn.textContent = isLight ? 'Disable light mode' : 'Enable light mode';
+      }
+
+      let stored = null;
+      try {
+        stored = localStorage.getItem(STORAGE_KEY);
+      } catch (err) {
+        stored = null;
+      }
+      const prefersLight = window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches;
+      const initial = stored === null ? prefersLight : stored === 'true';
+      applyMode(initial);
+
+      toggleBtn.addEventListener('click', ()=>{
+        const isLight = !document.body.classList.contains(LIGHT_CLASS);
+        applyMode(isLight);
+        try { localStorage.setItem(STORAGE_KEY, String(isLight)); } catch (err) { /* ignore storage failures */ }
       });
     })();
   </script>


### PR DESCRIPTION
## Summary
- add a light mode toggle button at the bottom of the side menu with a persisted preference
- style the light theme so the board, menu, and controls adapt when light mode is enabled

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68e6aff1210c832d86eb3484abbd25e5