### PR TITLE
Enable arrow key navigation between input cells

### DIFF
--- a/index.html
+++ b/index.html
@@ -698,6 +698,14 @@
           if ((e.key === "Backspace" || e.key === "Delete") && e.target.value === "" && i > 0) {
             rowDiv.children[i - 1].focus();
           }
+          if (e.key === "ArrowLeft" && i > 0) {
+            e.preventDefault();
+            rowDiv.children[i - 1].focus();
+          }
+          if (e.key === "ArrowRight" && i < rowDiv.children.length - 1) {
+            e.preventDefault();
+            rowDiv.children[i + 1].focus();
+          }
         });
         rowDiv.appendChild(input);
       }


### PR DESCRIPTION
## Summary
- allow ArrowLeft and ArrowRight keys to move between active input cells
- prevent default arrow key behavior so focus changes consistently

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f94c44a7ac832d9dc1fc470fdf3c5a