### PR TITLE
Add links to Cordlle and original Godle

### DIFF
--- a/index.html
+++ b/index.html
@@ -206,11 +206,13 @@
     .tracker-char.used { text-decoration: line-through; color: #555; transform: scale(0.95); }
 
     .share-buttons { display: flex; gap: 1rem; margin-top: 1.5rem; justify-content: center; flex-wrap: wrap; }
-    .share-button { padding: 0.8rem 1.5rem; border-radius: 8px; border: none; cursor: pointer; font-size: 1rem; display: flex; align-items: center; gap: 0.5rem; font-weight: bold; transition: all 0.3s ease; }
+    .share-button { padding: 0.8rem 1.5rem; border-radius: 8px; border: none; cursor: pointer; font-size: 1rem; display: flex; align-items: center; gap: 0.5rem; font-weight: bold; transition: all 0.3s ease; text-decoration: none; }
     .share-button:hover { transform: translateY(-2px); box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3); }
     .share-button.twitter { background: #1DA1F2; color: white; }
     .share-button.facebook { background: #4267B2; color: white; }
     .share-button.copy { background: #333; color: white; }
+    .share-button.cordlle { background: #ffeb3b; color: #1a1a1a; }
+    .share-button.godle { background: rgba(0, 188, 212, 0.4); color: #0d2a30; }
     #copy-message { margin-top: 1rem; color: #00bcd4; display: none; animation: fadeIn 0.5s ease-in; }
     #share-results { margin-top: 2rem; display: none; text-align: center; animation: fadeIn 0.5s ease-in; }
 
@@ -399,6 +401,8 @@
     <button id="share-twitter" class="share-button twitter" type="button" aria-label="Share on X (Twitter)">Share on X</button>
     <button id="share-facebook" class="share-button facebook" type="button" aria-label="Share on Facebook">Share on Facebook</button>
     <button id="share-copy" class="share-button copy" type="button" aria-label="Copy results">Copy</button>
+    <a class="share-button cordlle" href="https://cordell33.github.io/Cordlle/" target="_blank" rel="noopener noreferrer">Try Cordlle</a>
+    <a class="share-button godle" href="https://cordell33.github.io/GodlePuzzle/" target="_blank" rel="noopener noreferrer">Original Godle</a>
   </div>
   <div id="copy-message" style="display:none; text-align:center; margin-top:.5rem;">Copied to clipboard ✅</div>
   <div id="tracker"></div>


### PR DESCRIPTION
## Summary
- add share section links for Cordlle and the original Godle next to the copy button
- style new links with brand-specific colors consistent with existing share buttons

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69409f2c11c0832db1c77bde88906a0f)