### PR TITLE
Make puzzle fit on mobile with responsive cell sizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,6 +64,8 @@
       align-items: flex-end;          /* anchor to the right */
       width: 100%;
       max-width: 28rem;
+      --cell-size: 3rem;
+      --cell-gap: 0.2rem;
     }
     .row { 
       display: flex; 
@@ -74,10 +76,10 @@
     .row.final-row { justify-content: flex-start; } /* final code row left-aligned */
 
     .cell { 
-      width: 3rem; 
-      height: 3rem; 
-      font-size: 1.5rem; 
-      margin: 0.2rem; 
+      width: var(--cell-size); 
+      height: var(--cell-size); 
+      font-size: calc(var(--cell-size) * 0.5); 
+      margin: var(--cell-gap); 
       text-align: center; 
       border: 2px solid #444; 
       border-radius: 8px; 
@@ -220,10 +222,18 @@
 
     @media (max-width: 600px) {
       body { padding: 1rem; }
-      .cell { width: 2.8rem; height: 2.8rem; font-size: 1.3rem; }
+      .guesses { max-width: 100%; }
+      .guesses { --cell-size: 2.8rem; }
       .game-area { flex-direction: column; align-items: center; }
       .questions { min-width: 100%; }
       h1 { font-size: 2.2rem; }
+    }
+
+    @media (max-width: 480px) {
+      .guesses {
+        --cell-size: clamp(2.1rem, 9vw, 2.6rem);
+        --cell-gap: clamp(0.12rem, 1vw, 0.18rem);
+      }
     }
 
     @keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }


### PR DESCRIPTION
### Motivation
- Ensure the pyramid puzzle fits on narrow/mobile screens without horizontal overflow or tiny touch targets. 
- Make cell sizing adaptive so the board scales gracefully across a range of viewport widths. 

### Description
- Introduced CSS variables `--cell-size` and `--cell-gap` and updated `.cell` to use these variables and a responsive `font-size` calculation in `index.html`. 
- Added a small-screen rule to set `--cell-size` at `max-width: 600px` and a tighter `@media (max-width: 480px)` rule that uses `clamp()` to scale cells proportionally. 
- Kept the `.guesses` area full width on narrow viewports by changing `max-width` behavior so the board can shrink to fit. 

### Testing
- Launched a local HTTP server and used a headless browser (Playwright) to open `index.html` at a mobile viewport (`390x844`) and captured a screenshot to verify the puzzle fits (artifact: `mobile-fit.png`).
- No unit/test-suite commands were executed; dev self-tests exist as `runTests()` in the page but were not invoked during this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949f7f09e94832d8c6b979a6f086a54)