### PR TITLE
Move mobile off-canvas menu to open from the right

### DIFF
--- a/index.html
+++ b/index.html
@@ -227,6 +227,15 @@
       .game-area { flex-direction: column; align-items: center; }
       .questions { min-width: 100%; }
       h1 { font-size: 2.2rem; }
+
+      /* Mobile-only menu placement (opens from right side) */
+      #menu-toggle { left: auto; right: 1rem; }
+      #side-menu {
+        left: auto;
+        right: 0;
+        box-shadow: -8px 0 24px rgba(0, 0, 0, 0.45);
+        transform: translateX(100%);
+      }
     }
 
     @media (max-width: 480px) {


### PR DESCRIPTION
### Motivation
- On small screens the menu button and off-canvas panel should be anchored to the right and slide in from that side to match the requested mobile UX change.

### Description
- Added mobile-only CSS inside `@media (max-width: 600px)` to position the floating menu button on the right by setting `#menu-toggle { right: 1rem; left: auto; }`.
- Re-anchored the off-canvas panel to the right by setting `#side-menu { right: 0; left: auto; box-shadow: -8px 0 24px rgba(...); transform: translateX(100%); }` so the hidden state and slide-in animation come from the right.

### Testing
- Started a local server with `python3 -m http.server` and inspected the page in a mobile viewport; the menu toggles and appears from the right side (screenshot captured successfully).
- Ran `git diff --check` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a9ba45d54832d9e2a6e12e43a8177)