### PR TITLE
Move mobile menu toggle to right edge and center vertically

### DIFF
--- a/index.html
+++ b/index.html
@@ -228,8 +228,15 @@
       .questions { min-width: 100%; }
       h1 { font-size: 2.2rem; }
 
-      /* Mobile-only menu placement (opens from right side) */
-      #menu-toggle { left: auto; right: 1rem; }
+      /* Mobile-only menu placement (right side, vertically centered) */
+      #menu-toggle {
+        left: auto;
+        right: 0.75rem;
+        top: 50%;
+        transform: translateY(-50%);
+      }
+      #menu-toggle:hover { transform: translateY(calc(-50% - 1px)); }
+
       #side-menu {
         left: auto;
         right: 0;


### PR DESCRIPTION
### Motivation
- On small screens the menu toggle should appear on the right edge (not across the top) and open the drawer from the right to match mobile UX expectations.

### Description
- Adjusted CSS in `index.html` inside the `@media (max-width: 600px)` block to place `#menu-toggle` on the right edge, vertically centered (`right: 0.75rem; top: 50%; transform: translateY(-50%)`) and added a matching hover transform, while preserving the side menu's right-side off-canvas behavior (`right: 0; transform: translateX(100%)`).

### Testing
- Served the site with `python3 -m http.server 4173 --directory /workspace/GodleHex` and verified the layout with a Playwright mobile viewport load that saved `artifacts/mobile-menu-right.png`, and inspected the change with `git diff -- index.html`; all automated checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699aa7f08bd8832d99402195f651f9c6)