### PR TITLE
Harden iPhone mobile menu button placement in top-right corner

### DIFF
--- a/index.html
+++ b/index.html
@@ -228,14 +228,6 @@
       .questions { min-width: 100%; }
       h1 { font-size: 2.2rem; }
 
-      /* Mobile-only menu placement (opens from right side) */
-      #menu-toggle { left: auto; right: 1rem; }
-      #side-menu {
-        left: auto;
-        right: 0;
-        box-shadow: -8px 0 24px rgba(0, 0, 0, 0.45);
-        transform: translateX(100%);
-      }
     }
 
     @media (max-width: 480px) {
@@ -302,6 +294,28 @@
     .menu-open #menu-backdrop { opacity: 1; pointer-events: auto; }
     .menu-open #side-menu { transform: translateX(0); }
     .menu-open #menu-toggle { background:#2b2b2b; color:#ffb3b3; }
+
+
+    @media (max-width: 600px) {
+      /* Mobile-only menu placement (top-right corner) */
+      #menu-toggle {
+        left: auto !important;
+        right: max(0.75rem, env(safe-area-inset-right)) !important;
+        top: max(1rem, env(safe-area-inset-top)) !important;
+        width: auto;
+        max-width: max-content;
+        display: inline-flex;
+        white-space: nowrap;
+        transform: none !important;
+      }
+
+      #side-menu {
+        left: auto;
+        right: 0;
+        box-shadow: -8px 0 24px rgba(0, 0, 0, 0.45);
+        transform: translateX(100%);
+      }
+    }
 
     /* Motion safety */
     @media (prefers-reduced-motion: reduce) { #menu-backdrop, #side-menu, #menu-toggle { transition: none !important; } }


### PR DESCRIPTION
### Motivation
- The menu toggle was still stretching across the top on some mobile devices (notably iPhone with safe-area insets), so the mobile toggle needs stronger, safe-area-aware CSS to keep it pinned to the top-right corner. 
- The intent is to keep the off-canvas drawer opening from the right unchanged while preventing the toggle from becoming full-width.

### Description
- Tightened the mobile `@media (max-width: 600px)` rule in `index.html` to force `#menu-toggle` to the top-right using `left: auto !important`, `right: max(0.75rem, env(safe-area-inset-right)) !important`, and `top: max(1rem, env(safe-area-inset-top)) !important`.
- Added compact sizing and layout constraints for the toggle with `width: auto`, `max-width: max-content`, `display: inline-flex`, and `white-space: nowrap` to prevent full-width/top-bar stretching.
- Applied `transform: none !important` to avoid conflicting vertical transforms and left the `#side-menu` right-side off-canvas behavior intact (`right: 0` with `transform: translateX(100%)` closed state).

### Testing
- Served the app with `python3 -m http.server 4173 --directory /workspace/GodleHex` and the server started successfully. 
- Ran a Playwright script in a mobile viewport (`width: 390, height: 844`) that loaded `http://127.0.0.1:4173/index.html` and captured closed/open screenshots (`artifacts/mobile-menu-top-right-iphone-fix.png` and `artifacts/mobile-menu-top-right-iphone-fix-open.png`) which completed successfully. 
- Visually inspected the updated mobile rule in `index.html` to confirm the intended style overrides were present and effective.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699aa7f08bd8832d99402195f651f9c6)