### PR TITLE
Update side menu login label to 'Players email (username)'

### DIFF
--- a/index.html
+++ b/index.html
@@ -403,7 +403,7 @@
     <p>Sign in to track your streak, then use the Start Game button below the board whenever you're ready to play.</p>
     <div class="login-panel" aria-live="polite">
       <form id="login-form">
-        <label for="username-input">Player username</label>
+        <label for="username-input">Players email (username)</label>
         <div class="login-row">
           <input id="username-input" name="username" type="text" placeholder="Enter username" autocomplete="nickname" required />
           <button type="submit" id="login-button">Log In</button>


### PR DESCRIPTION
### Motivation
- Clarify the login field wording to indicate an email is expected while preserving the username concept for streak tracking.

### Description
- Replace the side menu login label text in `index.html` from `Player username` to `Players email (username)`.

### Testing
- Verified the text change by running `rg -n "Players email|Player username" index.html`, `git diff -- index.html`, and inspecting the file region with `nl -ba index.html | sed -n '400,412p'`, all showing the updated label.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8212cd1f0832d8a134e32bca829af)