### PR TITLE
Fix side menu player email label apostrophe

### DIFF
--- a/index.html
+++ b/index.html
@@ -403,7 +403,7 @@
     <p>Sign in to track your streak, then use the Start Game button below the board whenever you're ready to play.</p>
     <div class="login-panel" aria-live="polite">
       <form id="login-form">
-        <label for="username-input">Players email (username)</label>
+        <label for="username-input">Player’s email (username)</label>
         <div class="login-row">
           <input id="username-input" name="username" type="text" placeholder="Enter username" autocomplete="nickname" required />
           <button type="submit" id="login-button">Log In</button>


### PR DESCRIPTION
### Motivation
- Correct the side menu label to use proper possessive punctuation for improved readability and grammar.

### Description
- Replace the label text in `index.html` from `Players email (username)` to `Player’s email (username)`.

### Testing
- Verified the change by checking the file and output of `git status`, `nl -ba index.html | sed -n '396,414p'`, and confirming a successful commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e22be90d98832d890c624a1133ae23)