### PR TITLE
Add mobile-only landscape guidance and shift game area on mobile landscape

### DIFF
--- a/index.html
+++ b/index.html
@@ -178,6 +178,11 @@
       transition: all 0.3s ease;
     }
     #start-button:hover { background: #e02d2d; transform: translateY(-3px); box-shadow: 0 6px 12px rgba(0, 0, 0, 0.3); }
+    .mobile-landscape-message {
+      display: none;
+      margin: 1.5rem 0 -0.5rem;
+      font-weight: 700;
+    }
 
     #timer { margin-top: 1rem; font-size: 1.3rem; color: #ff3b3b; font-weight: bold; }
     #hex-digits-label { margin-top: 0.35rem; font-size: 1.1rem; color: #ccc; }
@@ -250,6 +255,16 @@
       .guesses {
         --cell-size: clamp(2.1rem, 9vw, 2.6rem);
         --cell-gap: clamp(0.12rem, 1vw, 0.18rem);
+      }
+    }
+
+    @media (hover: none) and (pointer: coarse) {
+      .mobile-landscape-message { display: block; }
+    }
+
+    @media (hover: none) and (pointer: coarse) and (orientation: landscape) {
+      .game-area {
+        transform: translateX(1.5rem);
       }
     }
 
@@ -399,6 +414,7 @@
       <li>One digit won’t be used and is placed at the begining of the final 7-character row.</li>
       <li>Good luck!</li>
     </ul>
+    <p class="mobile-landscape-message"><strong>Play in landscape for a better User Interface</strong></p>
     <button id="start-button">Start Game</button>
   </div>
 


### PR DESCRIPTION
### Motivation
- Improve usability on mobile devices by prompting users to rotate to landscape so the UI fits better and the puzzle is fully visible.
- Nudge the layout in mobile landscape so the puzzle board has additional horizontal space and is not cropped.

### Description
- Added a hidden-by-default paragraph `<p class="mobile-landscape-message"><strong>Play in landscape for a better User Interface</strong></p>` placed before the `#start-button` on the welcome screen. 
- Added `.mobile-landscape-message` CSS and a media query `@media (hover: none) and (pointer: coarse)` to show the message only on touch/mobile devices. 
- Added an extra media rule `@media (hover: none) and (pointer: coarse) and (orientation: landscape)` that applies `transform: translateX(1.5rem)` to `.game-area` to shift the game to the right in mobile landscape. 
- Kept the change purely presentational (CSS/HTML) so desktop and non-touch devices are unaffected.

### Testing
- Ran `git diff --check` to validate whitespace and basic diff checks and it completed without errors. 
- Parsed `index.html` with `python3 - <<'PY' ... HTMLParser().feed(...) ... PY` to ensure the HTML is well-formed and parsing succeeded. 
- Served the site with `python3 -m http.server` and fetched the page with `curl -fsS http://127.0.0.1:8000/index.html` to confirm the modified page is served. 
- Attempted `node -e "require('playwright')..."` but Playwright is not installed in this environment so browser-based visual testing was not run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3037342354832d93bf866020d48609)