### PR TITLE
Replace footer attribution with © 2026 Godle Games LLC

### DIFF
--- a/index.html
+++ b/index.html
@@ -478,7 +478,7 @@
   </div>
   <div id="copy-message" style="display:none; text-align:center; margin-top:.5rem;">Copied to clipboard ✅</div>
   <div id="tracker"></div>
-  <footer>created by Cordell Booth</footer>
+  <footer>© 2026 Godle Games LLC</footer>
 
   <script>
     // ===== Slide Menu Controller =====


### PR DESCRIPTION
### Motivation
- Update the site footer to reflect the new copyright holder and year by replacing the old creator attribution with the current company notice.

### Description
- Replaced the footer text `created by Cordell Booth` with `© 2026 Godle Games LLC` in `index.html`.

### Testing
- Verified the change with `rg -n "© 2026 Godle Games LLC|created by Cordell Booth" index.html`, which confirmed the new text is present and the old text is absent.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e912654c8832d9f11a990d1ce9104)